### PR TITLE
Added credentials in Properties file and updated steps for hiding the…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.features>src/test/resources/features</cucumber.features>
     </properties>
 
     <dependencies>
@@ -87,6 +88,18 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/TestRunner.java</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <cucumber.features>${cucumber.features}</cucumber.features>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/assessment/pages/interactions/LoginPageInteraction.java
+++ b/src/main/java/com/assessment/pages/interactions/LoginPageInteraction.java
@@ -83,10 +83,9 @@ public class LoginPageInteraction {
    * @param field String
    */
   public void enterDataInExpectedField(String data, String field) {
-    Log.debug(String.format("Entering: %s in %s", data, field));
+    Log.debug(String.format("Entering data in the field: %s", field));
     WebElement element = waitUtility.waitForElementToBeClickable(getLoginPageElementLocator(field));
     element.sendKeys(data);
-    Log.info(String.format("Entered: %s in %s", data, field));
   }
 
   /**
@@ -95,7 +94,6 @@ public class LoginPageInteraction {
   public void clickSubmitButton() {
     Log.debug("Clicking Submit button");
     waitUtility.waitForElementToBeClickable(loginPageModel.getLoginButton()).click();
-    Log.info("Clicked Submit button");
   }
 
   /**

--- a/src/main/java/com/assessment/pages/interactions/OperationCalendarPageInteraction.java
+++ b/src/main/java/com/assessment/pages/interactions/OperationCalendarPageInteraction.java
@@ -17,6 +17,7 @@ public class OperationCalendarPageInteraction {
   private final WaitUtility waitUtility;
   private final WebDriver driver;
   private final OperationCalendarPageModel operationCalendarPageModel;
+
   /**
    * Constructor to initialize dependencies.
    *

--- a/src/test/java/hooks/Hooks.java
+++ b/src/test/java/hooks/Hooks.java
@@ -1,6 +1,8 @@
 package hooks;
 
 import com.assessment.utilities.DriverManager;
+import com.aventstack.extentreports.MediaEntityBuilder;
+import com.aventstack.extentreports.cucumber.adapter.ExtentCucumberAdapter;
 import io.cucumber.java.*;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -30,11 +32,17 @@ public class Hooks {
    * @param scenario Cucumber scenario
    */
   @AfterStep
-  public void afterStep(io.cucumber.java.Scenario scenario) {
-    if (scenario.isFailed()) {
-      byte[] src = ((TakesScreenshot) driverManager.getDriver()).getScreenshotAs(OutputType.BYTES);
-      scenario.attach(src, "image/png", "failure");
-    }
+  public void afterStep(Scenario scenario) {if (scenario.isFailed()) {
+    String screenshotBase64 = ((TakesScreenshot)driverManager.getDriver())
+            .getScreenshotAs(OutputType.BASE64);
+
+    // 1. For ExtentReports
+    ExtentCucumberAdapter.getCurrentStep().fail(
+            MediaEntityBuilder.createScreenCaptureFromBase64String(screenshotBase64).build());
+
+    // 2. For Cucumber HTML report
+    scenario.attach(screenshotBase64, "image/png", "Failure");
+  }
   }
 
   /**

--- a/src/test/java/runners/TestRunner.java
+++ b/src/test/java/runners/TestRunner.java
@@ -1,15 +1,22 @@
 package runners;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.DataProvider;
 
 @CucumberOptions(
         features = "src/test/resources/features",
         glue = {"stepdefinitions", "hooks", "com.assessment.pages.interactions", "com.assessment.utilities"},
         plugin = {
                 "pretty",
-                "html:target/cucumber-report.html",
+                "html:target/cucumber-reports/cucumber.html",
                 "com.aventstack.extentreports.cucumber.adapter.ExtentCucumberAdapter:"
         },
         monochrome = true
 )
-public class TestRunner extends AbstractTestNGCucumberTests {}
+public class TestRunner extends AbstractTestNGCucumberTests {
+        @Override
+        @DataProvider(parallel = true)
+        public Object[][] scenarios() {
+                return super.scenarios();
+        }
+}

--- a/src/test/java/stepdefinitions/LoginSteps.java
+++ b/src/test/java/stepdefinitions/LoginSteps.java
@@ -1,5 +1,6 @@
 package stepdefinitions;
 import com.assessment.utilities.Log;
+import com.assessment.utilities.PropertiesUtility;
 import io.cucumber.java.en.*;
 import com.assessment.pages.interactions.LoginPageInteraction;
 import com.assessment.utilities.ConfigReader;
@@ -33,12 +34,20 @@ public class LoginSteps {
   /**
    * Enters the username and password in the login page fields.
    *
-   * @param data String
+   * @param ignoredUsernamePlaceholder String It is ignored as it is used for reporting purposes only
    * @param field String
+   * @param propertiesFile String
    */
-  @When("I enter {string} in {string} field in the login page")
-  public void enterDataInExpectedField(String data, String field){
-    Log.info(String.format("Enters the username: %s and password: %s in the login page fields", data, field));
+  @When("I enter {string} in {string} field in the login page from {string}")
+  public void enterDataInExpectedField(String ignoredUsernamePlaceholder, String field, String propertiesFile) {
+    Log.info(String.format("Enters the data in the field: %s", field));
+    String data = "";
+    // Get actual credentials from properties file
+    if(field.equalsIgnoreCase("username")){
+      data = PropertiesUtility.getProperty(propertiesFile, "username");
+    } else if(field.equalsIgnoreCase("password")){
+      data = PropertiesUtility.getProperty(propertiesFile, "password");
+    }
     loginPageInteraction.enterDataInExpectedField(data, field);
   }
 
@@ -60,20 +69,24 @@ public class LoginSteps {
   public void validateUserLoggedInSuccessfully(String expectedValue) {
     Log.info(String.format("Validating logged in page displays expected success toast message: %s", expectedValue));
     String actualValue = loginPageInteraction.getSuccessToastMessage();
-    Assert.assertTrue(actualValue.contains(expectedValue), "Login success message is not displayed");
+    Assert.assertTrue(actualValue.contains(expectedValue), "Login success message is not as displayed");
   }
 
   /**
    * Login steps with username and password.
    *
-   * @param username String
-   * @param password String
+   * @param ignoredUsernamePlaceholder String It is ignored as it is used for reporting purposes only
+   * @param ignoredPasswordPlaceholder String It is ignored as it is used for reporting purposes only
+   * @param propertiesFile String
    */
-  @When("I login with {string} and {string}")
-  public void loginToSite(String username, String password) {
-    Log.info(String.format("Logins with username: %s and password: %s", username, password));
-    enterDataInExpectedField(username, "username");
-    enterDataInExpectedField(password, "password");
+  @When("I login with username {string} and password {string} from {string}")
+  public void loginToSite(String ignoredUsernamePlaceholder, String ignoredPasswordPlaceholder, String propertiesFile) {
+    // Get actual credentials from properties file
+    String username = PropertiesUtility.getProperty(propertiesFile, "username");
+    String password = PropertiesUtility.getProperty(propertiesFile, "password");
+    Log.info(String.format("Logins with username: %s and password: %s fetched from file: %s", username, "****", propertiesFile));
+    enterDataInExpectedField(username, "username", propertiesFile);
+    enterDataInExpectedField(password, "password", propertiesFile);
     clickSubmitButton();
   }
 

--- a/src/test/resources/extent.properties
+++ b/src/test/resources/extent.properties
@@ -1,6 +1,4 @@
 extent.reporter.spark.start=true
-extent.reporter.spark.out=target/SparkReport/Spark.html
-basefolder.name=test-output/SparkReport
-basefolder.datetimepattern=d-MMM-yy_HH-mm-ss
-screenshot.dir=Screenshots/
-screenshot.rel.path=../Screenshots/
+extent.reporter.spark.out=test-output/SparkReport/Spark.html
+screenshot.dir=test-output/Screenshots/
+screenshot.rel.path=./Screenshots/

--- a/src/test/resources/features/login.feature
+++ b/src/test/resources/features/login.feature
@@ -1,34 +1,40 @@
 @LoginFlow
 Feature: Login Feature
 
-  @TICKET-1 @LoginFlow @Regression @FE
+  @LoginTest-1 @LoginFlow @Regression @FE
   Scenario Outline: Validate User is able to Login successfully
     Given I open the Test environment
-    When I enter "<username>" in "username" field in the login page
-    And I enter "<password>" in "password" field in the login page
+    When I enter "<username>" in "username" field in the login page from "<properties_file>"
+    And I enter "<password>" in "password" field in the login page from "<properties_file>"
     And I click on Submit button in the login page
     Then I should see "<result>" toast
     Examples:
-      | username        | password | result  |
-      | test@gmail.com  | test123  | success |
+      | properties_file             | username          | password       | result  |
+      | login.properties | ${login.username} | ${login.password} | success |
 
-  @TICKET-2 @LoginFlow @Regression @FE
-  Scenario: Validate error message when Incorrect Email Format is entered
+  @LoginTest-2 @LoginFlow @Regression @FE
+  Scenario Outline: Validate error message when Incorrect Email Format is entered
     Given I open the Test environment
-    When I enter "testgmailcom" in "username" field in the login page
-    And I enter "test123" in "password" field in the login page
+    When I enter "<username>" in "username" field in the login page from "<properties_file>"
+    And I enter "<password>" in "password" field in the login page from "<properties_file>"
     And I click on Submit button in the login page
-    Then I should see "enter correct email" error message
+    Then I should see "<result>" error message
+    Examples:
+      | properties_file             | username          | password       | result  |
+      | login.properties | ${login.username} | ${login.password} | enter correct email |
 
-  @TICKET-3 @LoginFlow @Regression @FE
-  Scenario: Validate error message when username (not registered) is entered
+  @LoginTest-3 @LoginFlow @Regression @FE
+  Scenario Outline: Validate error message when username (not registered) is entered
     Given I open the Test environment
-    When I enter "123@gmail.com" in "username" field in the login page
-    And I enter "test123" in "password" field in the login page
+    When I enter "<username>" in "username" field in the login page from "<properties_file>"
+    And I enter "<password>" in "password" field in the login page from "<properties_file>"
     And I click on Submit button in the login page
-    Then I should see "invalid email" error message
+    Then I should see "<result>" error message
+    Examples:
+      | properties_file             | username          | password       | result  |
+      | login.properties | ${login.username} | ${login.password} | invalid email |
 
-  @TICKET-4 @LoginFlow @Regression @FE
+  @LoginTest-4 @LoginFlow @Regression @FE
   Scenario: Validate Login page
     Given I open the Test environment
     Then I should see page title "Log in to VMD-SERAPIS-01"
@@ -37,13 +43,16 @@ Feature: Login Feature
     And I should see "Password" field
     And I should see "Login" button
 
-  @TICKET-5 @LoginFlow @Regression @FE
+  @LoginTest-5 @LoginFlow @Regression @FE
   Scenario: Validate Login button is disabled when username and password field are empty
     Given I open the Test environment
     Then I should see "Login" button is enabled false
 
-  @TICKET-6 @LoginFlow @Regression @FE
-  Scenario: Validate password is masked when password is entered
+  @LoginTest-6 @LoginFlow @Regression @FE
+  Scenario Outline: Validate password is masked when password is entered
     Given I open the Test environment
-    When I enter "test123" in "password" field in the login page
+    And I enter "<password>" in "password" field in the login page from "<properties_file>"
     Then I should see "Password" field is masked
+    Examples:
+      | properties_file             | password       |
+      | login.properties | ${login.password} |

--- a/src/test/resources/features/operationCalendar.feature
+++ b/src/test/resources/features/operationCalendar.feature
@@ -1,14 +1,14 @@
 @OperationCalendarFlow
 Feature: Operation Calendar feature
 
-  @TICKET-1 @OperationCalendarFlow @Regression @FE
+  @OperationCalendarTest-1 @OperationCalendarFlow @Regression @FE
   Scenario Outline: Validate selecting 5th list item from the Event dropdown list
     Given I open the Test environment
-    When I login with "username" and "password"
+    When I login with username "<username>" and password "<password>" from "login.properties"
     And I open the "operationCalendar" page
     And I expand the Event dropdown
     And I select the 5th item from the Event dropdown
     Then I should see the selected item matches "<expected_value_key>" from "<properties_file>"
     Examples:
-      | properties_file    | expected_value_key        |
-      | operationCalendar.properties | event.dropdown.expected.item_5  |
+      | properties_file             | expected_value_key             | username          | password       |
+      | operationCalendar.properties | event.dropdown.expected.item_5 | ${login.username} | ${login.password} |

--- a/src/test/resources/features/questionnarie.feature
+++ b/src/test/resources/features/questionnarie.feature
@@ -1,10 +1,13 @@
 @QuestionnaireFlow
 Feature: Questionnaire feature
 
-  @TICKET-1 @QuestionnaireFlow @Regression @FE
-  Scenario: Validate user is able to select Yes or No radio buttons for all questions randomly
+  @QuestionnaireTest-1 @QuestionnaireFlow @Regression @FE
+  Scenario Outline: Validate user is able to select Yes or No radio buttons for all questions randomly
     Given I open the Test environment
-    When I login with "username" and "password"
+    When I login with username "<username>" and password "<password>" from "login.properties"
     And I open the "questionnaire" page
     When I randomly select radio buttons for all questions
     Then I should see all questions at least 1 radio button selected
+    Examples:
+      | username          | password       |
+      | ${login.username} | ${login.password} |

--- a/src/test/resources/testData/login.properties
+++ b/src/test/resources/testData/login.properties
@@ -1,0 +1,2 @@
+username=test@gmail.com
+password=test123

--- a/src/test/resources/testngXmls/testng.xml
+++ b/src/test/resources/testngXmls/testng.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+
+<!--To run the xml cmd - mvn test "-DsuiteXmlFile=testng.xml" "-Dcucumber.filter.tags=@TagName" -->
+<suite name="Cucumber Tests" verbose="1" parallel="false">
+    <test name="Login Feature Tests with Tags">
+        <parameter name="cucumber.filter.tags" value="@LoginTest-1"/>
+        <classes>
+            <class name="io.cucumber.testng.TestNGCucumberRunner"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
- Added credentials in Properties file 
- Updated steps for hiding the credentials from reporting. 
- Added tesng.xml file for execution. 
- Updated screenshot logic for extent report

Executed testng xml with both pass scenario and fail scenario

pass scenario:
<img width="958" height="390" alt="image" src="https://github.com/user-attachments/assets/07d8a349-59a1-438f-9423-6fd28bc62597" />

fail scenario:
<img width="950" height="480" alt="image" src="https://github.com/user-attachments/assets/e80025a3-ded6-4619-92f3-cd7d3ede433a" />
